### PR TITLE
remove `false` value from tran version checker

### DIFF
--- a/app/checker/checker.go
+++ b/app/checker/checker.go
@@ -39,7 +39,7 @@ func Check(buildVersion string) {
 		return ""
 	}
 
-	if buildVersion != latestVersion && cfg.Tran.ShowUpdates != false {
+	if buildVersion != latestVersion && cfg.Tran.ShowUpdates {
 		fmt.Fprintf(stderr, "%s %s → %s\n",
 		ansi.Color("There's a new version of ", "yellow") + ansi.Color("tran", "cyan") + ansi.Color(" is avalaible:", "yellow"),
 		ansi.Color(buildVersion, "cyan"),


### PR DESCRIPTION
> should omit comparison to bool constant, can be simplified to `cfg.Tran.ShowUpdates`