### PR TITLE
feat: json schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "tran settings",
+  "description": "tran settings\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+  "type": "object",
+  "properties": {
+    "config": {
+      "title": "config",
+      "description": "tran settings\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+      "type": "object",
+      "properties": {
+        "borderless": {
+          "title": "borderless",
+          "description": "Whether to disable borders or not\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+          "type": "boolean",
+          "default": true
+        },
+        "editor": {
+          "title": "editor",
+          "description": "An editor\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[^ ]",
+          "default": "vim"
+        },
+        "enable_mousewheel": {
+          "title": "enable mouse wheel",
+          "description": "Whether to enable a mouse wheel or not\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+          "type": "boolean",
+          "default": true
+        },
+        "show_updates": {
+          "title": "show updates",
+          "description": "Whether to show updates or not\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+          "type": "boolean",
+          "default": true
+        },
+        "start_dir": {
+          "title": "starting directory",
+          "description": "A starting directory\nhttps://github.com/abdfnx/tran?tab=readme-ov-file#tran-config-file",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[^ ]",
+          "default": "."
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    }
+  },
+  "minProperties": 1,
+  "additionalProperties": false
+}


### PR DESCRIPTION

![image](https://github.com/abdfnx/tran/assets/42812113/875d1911-fb2c-48db-82e5-e08f86223492)

There are several possible ways of utilizing this schema ([YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension is required in VS Code to make them work):

- It can be referenced directly `# yaml-language-server: $schema={{schema url in this repository}}` in `~/.tran/tran.yml`, this is a manual approach because requires user to put a full URL by hand.
- It can be put in [SchemaStore](https://github.com/SchemaStore/schemastore) and referenced there like [this](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/markdownlint.json#L2). This approach ensures that whenever user edits `~/.tran/tran.yml` they get the latest hints for it.


> If this PR is accepted this schema is referenced in [SchemaStore](https://github.com/SchemaStore/schemastore) to automatically enable validation for `~/.tran/tran.yml`.

